### PR TITLE
Implement demo coach dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import LoginPage from './pages/LoginPage';
 import ClientDashboard from './pages/dashboard/ClientDashboard';
 import CoachDashboard from './pages/dashboard/CoachDashboard';
 
+
 function App() {
   return (
     <Router>
@@ -33,6 +34,11 @@ function App() {
           <Route path="connexion" element={<LoginPage />} />
         </Route>
         
+        {/* Demo coach accessible without inscription */}
+        <Route path="demo-coach" element={<DashboardLayout />}>
+          <Route index element={<CoachDashboard isDemo />} />
+        </Route>
+
         {/* Dashboard routes with DashboardLayout */}
         <Route path="/dashboard" element={<DashboardLayout />}>
           <Route path="client" element={<ClientDashboard />} />

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -81,12 +81,15 @@ const HomePage = () => {
               La plateforme professionnelle qui connecte coachs et clients pour un suivi fitness personnalisé et efficace.
             </p>
             <div className="flex flex-wrap gap-4">
-              <Link to="/inscription" className="btn-accent">
-                Créer mon compte
+              <Link to="/dashboard/coach" className="btn-accent inline-flex items-center">
+                Accéder à l'espace Coach
                 <ArrowRight className="ml-2 h-5 w-5" />
               </Link>
-              <Link to="/coachs" className="btn bg-white text-primary-900 hover:bg-gray-100">
-                Découvrir les coachs
+              <Link to="/dashboard/client" className="btn bg-white text-primary-900 hover:bg-gray-100">
+                Accéder à l'espace Client
+              </Link>
+              <Link to="/demo-coach" className="btn-outline text-white border-white hover:bg-white hover:text-primary-900">
+                Essayer la démo Coach
               </Link>
             </div>
           </div>

--- a/src/pages/dashboard/CoachDashboard.tsx
+++ b/src/pages/dashboard/CoachDashboard.tsx
@@ -3,7 +3,11 @@ import { Calendar, Users, CreditCard, BarChart2, TrendingUp, MessageSquare, Book
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 
-const CoachDashboard = () => {
+interface CoachDashboardProps {
+  isDemo?: boolean;
+}
+
+const CoachDashboard: React.FC<CoachDashboardProps> = ({ isDemo }) => {
   // Mock data for the dashboard
   const todaySessions = [
     {
@@ -80,6 +84,11 @@ const CoachDashboard = () => {
 
   return (
     <div className="animate-enter">
+      {isDemo && (
+        <div className="mb-4 p-3 text-sm rounded bg-orange-100 text-orange-800 text-center">
+          Vous utilisez la version démo. Les données sont fictives.
+        </div>
+      )}
       <div className="mb-8">
         <h1 className="text-2xl font-bold mb-2">Bienvenue, Thomas 👋</h1>
         <p className="text-gray-600">Voici un aperçu de votre activité aujourd'hui.</p>


### PR DESCRIPTION
## Summary
- add support for a demo banner in `CoachDashboard`
- update home page hero with coach/client buttons and link to demo
- define `/demo-coach` route rendering the coach dashboard in demo mode

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841860c1458832db22cf5c4e21e7bd6