### PR TITLE
Connect buttons and link blog posts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import AboutPage from './pages/AboutPage';
 import LoginPage from './pages/LoginPage';
 import SignUpPage from './pages/SignUpPage';
 import BlogPage from './pages/BlogPage';
+import BlogPostPage from './pages/BlogPostPage';
 import ContactPage from './pages/ContactPage';
 
 // Dashboard Pages
@@ -25,6 +26,8 @@ import SessionsPage from './pages/dashboard/SessionsPage';
 import ProgramsPage from './pages/dashboard/ProgramsPage';
 import ClientsPage from './pages/dashboard/ClientsPage';
 import MessagesPage from './pages/dashboard/MessagesPage';
+import ProfilePage from './pages/dashboard/ProfilePage';
+import SettingsPage from './pages/dashboard/SettingsPage';
 
 
 function App() {
@@ -42,6 +45,7 @@ function App() {
           <Route path="connexion" element={<LoginPage />} />
           <Route path="inscription" element={<SignUpPage />} />
           <Route path="blog" element={<BlogPage />} />
+          <Route path="blog/:id" element={<BlogPostPage />} />
           <Route path="contact" element={<ContactPage />} />
         </Route>
         
@@ -59,6 +63,8 @@ function App() {
           <Route path="programmes" element={<ProgramsPage />} />
           <Route path="clients" element={<ClientsPage />} />
           <Route path="messages" element={<MessagesPage />} />
+          <Route path="profil" element={<ProfilePage />} />
+          <Route path="parametres" element={<SettingsPage />} />
         </Route>
       </Routes>
     </Router>

--- a/src/layouts/DashboardLayout.tsx
+++ b/src/layouts/DashboardLayout.tsx
@@ -228,12 +228,13 @@ const DashboardLayout = () => {
                       </div>
                     )}
                     <div className="border-t border-gray-100">
-                      <a
-                        href="#"
+                      <Link
+                        to="/dashboard/messages"
                         className="block px-4 py-2 text-sm text-center text-primary-600 hover:bg-gray-50"
+                        onClick={() => setIsNotificationsOpen(false)}
                       >
                         Voir toutes les notifications
-                      </a>
+                      </Link>
                     </div>
                   </div>
                 )}
@@ -270,26 +271,28 @@ const DashboardLayout = () => {
                       <div className="font-medium">{currentUser.name}</div>
                       <div className="text-gray-500">{currentUser.email}</div>
                     </div>
-                    <a
-                      href="#"
+                    <Link
+                      to="/dashboard/profil"
                       className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
                       role="menuitem"
+                      onClick={() => setIsProfileMenuOpen(false)}
                     >
                       <div className="flex items-center">
                         <User className="mr-3 h-5 w-5 text-gray-400" />
                         Profil
                       </div>
-                    </a>
-                    <a
-                      href="#"
+                    </Link>
+                    <Link
+                      to="/dashboard/parametres"
                       className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
                       role="menuitem"
+                      onClick={() => setIsProfileMenuOpen(false)}
                     >
                       <div className="flex items-center">
                         <Settings className="mr-3 h-5 w-5 text-gray-400" />
                         Paramètres
                       </div>
-                    </a>
+                    </Link>
                     <button
                       onClick={handleSignOut}
                       className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -169,15 +169,30 @@ const MainLayout = () => {
                 Votre plateforme de coaching sportif personnalisé, pour atteindre vos objectifs avec un suivi professionnel.
               </p>
               <div className="mt-6 flex space-x-6">
-                <a href="#" className="text-gray-400 hover:text-white">
+                <a
+                  href="https://instagram.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-gray-400 hover:text-white"
+                >
                   <span className="sr-only">Instagram</span>
                   <Instagram className="h-6 w-6" />
                 </a>
-                <a href="#" className="text-gray-400 hover:text-white">
+                <a
+                  href="https://facebook.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-gray-400 hover:text-white"
+                >
                   <span className="sr-only">Facebook</span>
                   <Facebook className="h-6 w-6" />
                 </a>
-                <a href="#" className="text-gray-400 hover:text-white">
+                <a
+                  href="https://twitter.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-gray-400 hover:text-white"
+                >
                   <span className="sr-only">Twitter</span>
                   <Twitter className="h-6 w-6" />
                 </a>

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { blogPosts } from '../data/mockData';
 
 const BlogPage: React.FC = () => {
@@ -20,7 +21,9 @@ const BlogPage: React.FC = () => {
                 <h3 className="text-xl font-semibold mb-2">{post.title}</h3>
                 <p className="text-gray-600 mb-4">{post.excerpt}</p>
                 <div className="mt-auto">
-                  <button className="btn-outline w-full">Lire l'article</button>
+                  <Link to={`/blog/${post.id}`} className="btn-outline w-full">
+                    Lire l'article
+                  </Link>
                 </div>
               </div>
             </div>

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { blogPosts } from '../data/mockData';
+
+const BlogPostPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const post = blogPosts.find((p) => p.id === id);
+
+  if (!post) {
+    return (
+      <div className="py-16 text-center">
+        <h2 className="text-2xl font-semibold">Article non trouvé</h2>
+      </div>
+    );
+  }
+
+  return (
+    <div className="animate-enter py-16">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h1 className="text-3xl font-bold mb-4">{post.title}</h1>
+        <p className="text-gray-500 mb-8">
+          {new Date(post.date).toLocaleDateString('fr-FR')} - {post.author}
+        </p>
+        <img src={post.image} alt={post.title} className="mb-8 rounded-md" />
+        <div className="space-y-4 text-gray-700">
+          {post.content.split('\n').map((paragraph, idx) => (
+            <p key={idx}>{paragraph}</p>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BlogPostPage;

--- a/src/pages/CoachProfilePage.tsx
+++ b/src/pages/CoachProfilePage.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { Star, MapPin, Award, Clock, Calendar, Users } from 'lucide-react';
 import { coaches } from '../data/mockData';
 import SessionCard from '../components/common/SessionCard';
 
 const CoachProfilePage = () => {
   const { id } = useParams();
+  const navigate = useNavigate();
   const coach = coaches.find(c => c.id === id);
 
   if (!coach) {
@@ -150,10 +151,16 @@ const CoachProfilePage = () => {
           <div className="space-y-6">
             {/* Quick Actions */}
             <div className="card p-6">
-              <button className="btn-primary w-full mb-3">
+              <button
+                className="btn-primary w-full mb-3"
+                onClick={() => navigate('/inscription')}
+              >
                 Réserver une séance
               </button>
-              <button className="btn-outline w-full">
+              <button
+                className="btn-outline w-full"
+                onClick={() => navigate('/contact')}
+              >
                 Contacter
               </button>
             </div>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const LoginPage: React.FC = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [remember, setRemember] = useState(false);
   const [message, setMessage] = useState('');
+  const navigate = useNavigate();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -18,6 +20,7 @@ const LoginPage: React.FC = () => {
     setEmail('');
     setPassword('');
     setRemember(false);
+    navigate('/dashboard/client');
   };
 
   return (

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const SignUpPage: React.FC = () => {
   const [form, setForm] = useState({
@@ -9,6 +10,7 @@ const SignUpPage: React.FC = () => {
   });
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
+  const navigate = useNavigate();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -38,6 +40,7 @@ const SignUpPage: React.FC = () => {
     // In a real app we would send the data to the server here
     setSuccess('Compte créé avec succès !');
     setForm({ name: '', email: '', password: '', confirm: '' });
+    navigate('/dashboard/client');
   };
 
   return (

--- a/src/pages/dashboard/ClientDashboard.tsx
+++ b/src/pages/dashboard/ClientDashboard.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Calendar, Clock, Users, Activity, TrendingUp, Trophy } from 'lucide-react';
 import ProgressChart from '../../components/common/ProgressChart';
 
 const ClientDashboard = () => {
+  const navigate = useNavigate();
   // Mock data for the dashboard
   const upcomingSessions = [
     {
@@ -145,7 +147,10 @@ const ClientDashboard = () => {
                 <p className="text-gray-600">Aucune séance programmée</p>
               )}
               <div className="mt-4">
-                <button className="btn-primary w-full">
+                <button
+                  className="btn-primary w-full"
+                  onClick={() => navigate('/dashboard/seances')}
+                >
                   Réserver une séance
                 </button>
               </div>

--- a/src/pages/dashboard/CoachDashboard.tsx
+++ b/src/pages/dashboard/CoachDashboard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Calendar, Users, CreditCard, BarChart2, TrendingUp, MessageSquare, BookOpen } from 'lucide-react';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
@@ -8,6 +9,7 @@ interface CoachDashboardProps {
 }
 
 const CoachDashboard: React.FC<CoachDashboardProps> = ({ isDemo }) => {
+  const navigate = useNavigate();
   // Mock data for the dashboard
   const todaySessions = [
     {
@@ -182,19 +184,31 @@ const CoachDashboard: React.FC<CoachDashboardProps> = ({ isDemo }) => {
           <div className="card p-4">
             <h3 className="font-semibold mb-4">Actions rapides</h3>
             <div className="grid grid-cols-2 gap-3">
-              <button className="btn-primary text-sm py-2">
+              <button
+                className="btn-primary text-sm py-2"
+                onClick={() => navigate('/dashboard/seances')}
+              >
                 <Calendar className="h-4 w-4 mr-2" />
                 Nouvelle séance
               </button>
-              <button className="btn-outline text-sm py-2">
+              <button
+                className="btn-outline text-sm py-2"
+                onClick={() => navigate('/dashboard/clients')}
+              >
                 <Users className="h-4 w-4 mr-2" />
                 Ajouter client
               </button>
-              <button className="btn-outline text-sm py-2">
+              <button
+                className="btn-outline text-sm py-2"
+                onClick={() => navigate('/dashboard/programmes')}
+              >
                 <BookOpen className="h-4 w-4 mr-2" />
                 Créer programme
               </button>
-              <button className="btn-outline text-sm py-2">
+              <button
+                className="btn-outline text-sm py-2"
+                onClick={() => navigate('/dashboard/messages')}
+              >
                 <MessageSquare className="h-4 w-4 mr-2" />
                 Messages
               </button>
@@ -236,9 +250,12 @@ const CoachDashboard: React.FC<CoachDashboardProps> = ({ isDemo }) => {
               ))}
             </div>
             <div className="p-3 bg-gray-50 border-t text-center">
-              <a href="#" className="text-primary-600 text-sm font-medium hover:text-primary-700">
+              <button
+                className="text-primary-600 text-sm font-medium hover:text-primary-700"
+                onClick={() => navigate('/dashboard/clients')}
+              >
                 Voir tous les clients
-              </a>
+              </button>
             </div>
           </div>
 

--- a/src/pages/dashboard/ProfilePage.tsx
+++ b/src/pages/dashboard/ProfilePage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const ProfilePage: React.FC = () => {
+  return (
+    <div className="p-8 text-center">
+      <h1 className="text-2xl font-bold">Profil</h1>
+      <p className="mt-4">Cette page sera disponible prochainement.</p>
+    </div>
+  );
+};
+
+export default ProfilePage;

--- a/src/pages/dashboard/SettingsPage.tsx
+++ b/src/pages/dashboard/SettingsPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const SettingsPage: React.FC = () => {
+  return (
+    <div className="p-8 text-center">
+      <h1 className="text-2xl font-bold">Paramètres</h1>
+      <p className="mt-4">Les paramètres du compte seront disponibles bientôt.</p>
+    </div>
+  );
+};
+
+export default SettingsPage;


### PR DESCRIPTION
## Summary
- add missing navigation links on footer icons and dashboard menus
- connect quick action buttons and profile menu to new dashboard pages
- add client profile and settings placeholder pages
- connect signup/login flows to dashboard
- link blog articles to new blog post page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68445b82b69c832db86da58d6415c73c